### PR TITLE
Add a youtrack_release_link option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ JDK is not required because of embedded into archive version is used.
 | youtrack_user | User to run YouTrack service | `youtrack` |
 | youtrack_group | Group for YouTrack user | `{{ youtrack_user }}` |
 | youtrack_home_dir | Home directory for YouTrack user | `/home/{{ youtrack_user }}` |
-| youtrack_base_dir | Location of the symbolic link for the latest version of youtrack installed | `{{ youtrack_home_dir }}/youtrack` |
+| youtrack_release_link | Location of the symbolic link for the latest version of youtrack installed | `{{ youtrack_home_dir }}/youtrack` |
 | youtrack_data_dir | YouTrack data directory | `{{ youtrack_home_dir }}/data` |
 | youtrack_logs_dir | YouTrack logs directory | `{{ youtrack_home_dir }}/logs` |
 | youtrack_backups_dir | YouTrack backups directory | `{{ youtrack_home_dir }}/backups` |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ JDK is not required because of embedded into archive version is used.
 | youtrack_user | User to run YouTrack service | `youtrack` |
 | youtrack_group | Group for YouTrack user | `{{ youtrack_user }}` |
 | youtrack_home_dir | Home directory for YouTrack user | `/home/{{ youtrack_user }}` |
+| youtrack_base_dir | Location of the symbolic link for the latest version of youtrack installed | `{{ youtrack_home_dir }}/youtrack` |
 | youtrack_data_dir | YouTrack data directory | `{{ youtrack_home_dir }}/data` |
 | youtrack_logs_dir | YouTrack logs directory | `{{ youtrack_home_dir }}/logs` |
 | youtrack_backups_dir | YouTrack backups directory | `{{ youtrack_home_dir }}/backups` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ youtrack_create_user: true
 youtrack_user: youtrack
 youtrack_group: "{{ youtrack_user }}"
 youtrack_home_dir: "/home/{{ youtrack_user }}"
+youtrack_base_dir: "{{ youtrack_home_dir }}/youtrack"
 youtrack_data_dir: "{{ youtrack_home_dir }}/data"
 youtrack_logs_dir: "{{ youtrack_home_dir }}/logs"
 youtrack_backups_dir: "{{ youtrack_home_dir }}/backups"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ youtrack_create_user: true
 youtrack_user: youtrack
 youtrack_group: "{{ youtrack_user }}"
 youtrack_home_dir: "/home/{{ youtrack_user }}"
-youtrack_base_dir: "{{ youtrack_home_dir }}/youtrack"
+youtrack_release_link: "{{ youtrack_home_dir }}/youtrack"
 youtrack_data_dir: "{{ youtrack_home_dir }}/data"
 youtrack_logs_dir: "{{ youtrack_home_dir }}/logs"
 youtrack_backups_dir: "{{ youtrack_home_dir }}/backups"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 - name: configure | check for current link
   ansible.builtin.stat:
-    path: "{{ youtrack_home_dir }}/youtrack"
+    path: "{{ youtrack_base_dir }}"
   register: __link
 
 - name: configure | extract current version

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 - name: configure | check for current link
   ansible.builtin.stat:
-    path: "{{ youtrack_base_dir }}"
+    path: "{{ youtrack_release_link }}"
   register: __link
 
 - name: configure | extract current version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     state: link
     follow: no
     src: "{{ youtrack_releases_dir }}/youtrack-{{ youtrack_version }}"
-    dest: "{{ youtrack_home_dir }}/youtrack"
+    dest: "{{ youtrack_base_dir }}"
     owner: "{{ youtrack_user }}"
     group: "{{ youtrack_group }}"
   notify: restart youtrack service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     state: link
     follow: no
     src: "{{ youtrack_releases_dir }}/youtrack-{{ youtrack_version }}"
-    dest: "{{ youtrack_base_dir }}"
+    dest: "{{ youtrack_release_link }}"
     owner: "{{ youtrack_user }}"
     group: "{{ youtrack_group }}"
   notify: restart youtrack service

--- a/templates/youtrack.service.j2
+++ b/templates/youtrack.service.j2
@@ -12,10 +12,10 @@ RemainAfterExit=yes
 User={{ youtrack_user }}
 Group={{ youtrack_group }}
 SyslogIdentifier=youtrack
-WorkingDirectory={{ youtrack_base_dir }}
+WorkingDirectory={{ youtrack_release_link }}
 PIDFile={{ youtrack_logs_dir }}/youtrack.pid
 RestartSec=5
 Restart=on-failure
 
-ExecStart={{ youtrack_base_dir }}/bin/youtrack.sh start --no-browser
-ExecStop={{ youtrack_base_dir }}/bin/youtrack.sh stop
+ExecStart={{ youtrack_release_link }}/bin/youtrack.sh start --no-browser
+ExecStop={{ youtrack_release_link }}/bin/youtrack.sh stop

--- a/templates/youtrack.service.j2
+++ b/templates/youtrack.service.j2
@@ -12,10 +12,10 @@ RemainAfterExit=yes
 User={{ youtrack_user }}
 Group={{ youtrack_group }}
 SyslogIdentifier=youtrack
-WorkingDirectory={{ youtrack_home_dir }}
+WorkingDirectory={{ youtrack_base_dir }}
 PIDFile={{ youtrack_logs_dir }}/youtrack.pid
 RestartSec=5
 Restart=on-failure
 
-ExecStart={{ youtrack_home_dir }}/youtrack/bin/youtrack.sh start --no-browser
-ExecStop={{ youtrack_home_dir }}/youtrack/bin/youtrack.sh stop
+ExecStart={{ youtrack_base_dir }}/bin/youtrack.sh start --no-browser
+ExecStop={{ youtrack_base_dir }}/bin/youtrack.sh stop


### PR DESCRIPTION
feat: Add `youtrack_release_link` variable that specifies where the youtrack symbolic link is targeted, allowing you to move it outside of `youtrack_home_dir`. Closes issue #5 